### PR TITLE
suppress catkin warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Java)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 catkin_package(
-  DEPENDS LCM Java 
+  DEPENDS LCM
   CFG_EXTRAS lcmtypes.cmake
 )
 


### PR DESCRIPTION
this package will die soon. Until then, at least no warnings will be
displayed anymore.